### PR TITLE
Added tests for calculating/verification absolute and relative paths

### DIFF
--- a/sha256sum.vcxproj
+++ b/sha256sum.vcxproj
@@ -31,7 +31,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{0d52e9d4-df97-4975-854e-3bc74d9a0731}</ProjectGuid>
     <RootNamespace>sha256sum</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -68,7 +68,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>

--- a/sha256sum.vcxproj
+++ b/sha256sum.vcxproj
@@ -148,6 +148,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>Shlwapi.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Tests|x64'">

--- a/tests/sha256.cpp
+++ b/tests/sha256.cpp
@@ -18,7 +18,7 @@ public:
         ErrorCode act = CalcHash(&args, &hash, file);
         ErrorCode exp = SUCCESS;
 
-        Assert::AreEqual((int)act, (int)exp);
+        Assert::AreEqual((int)exp, (int)act);
         Assert::AreEqual(L"5825c4a88eddd074eb3c12b23dedc0eb4d7d5f2356a61a4078a0bd3ccf69c7a1", hash);
     }
 };
@@ -36,7 +36,7 @@ public:
         ErrorCode act = VerifyChecksums(&args);
         ErrorCode exp = SUCCESS;
 
-        Assert::AreEqual((int)act, (int)exp);
+        Assert::AreEqual((int)exp, (int)act);
     }
 
     TEST_METHOD(TestFailure)
@@ -48,7 +48,7 @@ public:
         ErrorCode act = VerifyChecksums(&args);
         ErrorCode exp = CHECK_SUM_CHECKSUM_FAILED;
 
-        Assert::AreEqual((int)act, (int)exp);
+        Assert::AreEqual((int)exp, (int)act);
     }
 };
 }

--- a/tests/sha256.cpp
+++ b/tests/sha256.cpp
@@ -1,6 +1,12 @@
 #include "pch.h"
 #include "CppUnitTest.h"
 #include <sha256sum.h>
+#include <direct.h>
+#define GetCurrentDir _getcwd
+#include <stdio.h>
+#include <string>
+#include <iostream>
+#include <fstream>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -9,10 +15,80 @@ TEST_CLASS(fCalcHash)
 {
 public:
 
-    TEST_METHOD(TestValidHash)
+    TEST_METHOD(TestValidHashCurrentPath)
     {
         Args args = { 0 };
         LPWSTR file = L"CalcHashTestFile.txt";
+
+        LPWSTR hash = NULL;
+        ErrorCode act = CalcHash(&args, &hash, file);
+        ErrorCode exp = SUCCESS;
+
+        Assert::AreEqual((int)exp, (int)act);
+        Assert::AreEqual(L"5825c4a88eddd074eb3c12b23dedc0eb4d7d5f2356a61a4078a0bd3ccf69c7a1", hash);
+    }
+
+    TEST_METHOD(TestValidHashMissingFile)
+    {
+        Args args = { 0 };
+        LPWSTR file = L"Missing.txt";
+
+        LPWSTR hash = NULL;
+        ErrorCode act = CalcHash(&args, &hash, file);
+        ErrorCode exp = CALC_HASH_FAILED_TO_OPEN_FILE;
+
+        Assert::AreEqual((int)exp, (int)act);
+    }
+
+    TEST_METHOD(TestValidHashAbsolutePath)
+    {
+        char cwd[FILENAME_MAX];
+        if (!GetCurrentDir(cwd, sizeof(cwd)))
+        {
+            Assert::Fail(L"Can't get current path");
+            return;
+        }
+
+        std::string fullPath = std::string(cwd) + "\\CalcHashTestFile.txt";
+        std::wstring wideFullPath(fullPath.begin(), fullPath.end());
+
+        Args args = { 0 };
+        LPWSTR file = &wideFullPath[0];
+
+        LPWSTR hash = NULL;
+        ErrorCode act = CalcHash(&args, &hash, file);
+        ErrorCode exp = SUCCESS;
+
+        Assert::AreEqual((int)exp, (int)act);
+        Assert::AreEqual(L"5825c4a88eddd074eb3c12b23dedc0eb4d7d5f2356a61a4078a0bd3ccf69c7a1", hash);
+    }
+
+    TEST_METHOD(TestValidHashRelativePath)
+    {
+        char tempCwd[FILENAME_MAX];
+        if (!GetCurrentDir(tempCwd, sizeof(tempCwd)))
+        {
+            Assert::Fail(L"Can't get current path");
+            return;
+        }
+
+        std::string cwd(tempCwd);
+
+        size_t lastSeparator = cwd.find_last_of('\\');
+
+        std::string lastPart;
+        if (lastSeparator != std::string::npos) {
+            lastPart = cwd.substr(lastSeparator + 1);
+        }
+        else {
+            lastPart = cwd;
+        }
+
+        std::string fullPath = std::string(cwd) + "\\..\\" + lastPart + "\\CalcHashTestFile.txt";
+        std::wstring wideFullPath(fullPath.begin(), fullPath.end());
+
+        Args args = { 0 };
+        LPWSTR file = &wideFullPath[0];
 
         LPWSTR hash = NULL;
         ErrorCode act = CalcHash(&args, &hash, file);
@@ -27,10 +103,90 @@ TEST_CLASS(fVerifyChecksums)
 {
 public:
 
-    TEST_METHOD(TestSuccess)
+    TEST_METHOD(TestSuccessCurrentPath)
     {
         Args args = { 0 };
         args.sumFile = L"ShasumSuccess.txt";
+
+        LPWSTR hash = NULL;
+        ErrorCode act = VerifyChecksums(&args);
+        ErrorCode exp = SUCCESS;
+
+        Assert::AreEqual((int)exp, (int)act);
+    }
+
+    TEST_METHOD(TestSuccessAbsolutePath)
+    {
+        char cwd[FILENAME_MAX];
+        if (!GetCurrentDir(cwd, sizeof(cwd)))
+        {
+            Assert::Fail(L"Can't get current path");
+            return;
+        }
+
+        std::string expectedChecksum = "5825c4a88eddd074eb3c12b23dedc0eb4d7d5f2356a61a4078a0bd3ccf69c7a1";
+        std::string checksumFilename = "ShasumSuccessAbsolute.txt";
+        std::ofstream checksumFile(checksumFilename);
+
+        if (!checksumFile) {
+            Assert::Fail(L"Count not create checksum file");
+            return;
+        }
+
+        checksumFile << expectedChecksum << " *" << cwd << "\\CalcHashTestFile.txt" << std::endl;
+        checksumFile.close();
+
+        std::string fullPath = std::string(cwd) + "\\" + checksumFilename;
+
+        std::wstring wideFullPath(fullPath.begin(), fullPath.end());
+        Args args = { 0 };
+        args.sumFile = &wideFullPath[0];
+
+        LPWSTR hash = NULL;
+        ErrorCode act = VerifyChecksums(&args);
+        ErrorCode exp = SUCCESS;
+
+        Assert::AreEqual((int)exp, (int)act);
+    }
+
+    TEST_METHOD(TestSuccessRelativePath)
+    {
+        char tempCwd[FILENAME_MAX];
+        if (!GetCurrentDir(tempCwd, sizeof(tempCwd)))
+        {
+            Assert::Fail(L"Can't get current path");
+            return;
+        }
+
+        std::string cwd(tempCwd);
+
+        size_t lastSeparator = cwd.find_last_of('\\');
+
+        std::string lastPart;
+        if (lastSeparator != std::string::npos) {
+            lastPart = cwd.substr(lastSeparator + 1);
+        }
+        else {
+            lastPart = cwd;
+        }
+
+        std::string expectedChecksum = "5825c4a88eddd074eb3c12b23dedc0eb4d7d5f2356a61a4078a0bd3ccf69c7a1";
+        std::string checksumFilename = "ShasumSuccessRelative.txt";
+        std::ofstream checksumFile(checksumFilename);
+
+        if (!checksumFile) {
+            Assert::Fail(L"Count not create checksum file");
+            return;
+        }
+
+        checksumFile << expectedChecksum << " *" << "..\\" << lastPart << "\\CalcHashTestFile.txt" << std::endl;
+        checksumFile.close();
+
+        std::string fullPath = std::string(cwd) + "\\" + checksumFilename;
+
+        std::wstring wideFullPath(fullPath.begin(), fullPath.end());
+        Args args = { 0 };
+        args.sumFile = &wideFullPath[0];
 
         LPWSTR hash = NULL;
         ErrorCode act = VerifyChecksums(&args);

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -23,7 +23,7 @@
     <ProjectGuid>{8C494A81-1735-4AEF-804C-242C1AAE19A7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -106,8 +106,8 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(TargetDir);C:\src\sha256sum.exe\x64\Release\;sha256.obj;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>args.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(TargetDir);$(ProjectDir)..\sha256sum\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>args.obj;sha256.obj;Shlwapi.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -101,6 +101,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>Default</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,8 +138,8 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>$(TargetDir);$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>args.obj;sha256.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(TargetDir);$(VCInstallDir)UnitTest\lib;$(ProjectDir)..\sha256sum\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>args.obj;sha256.obj;Shlwapi.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">

--- a/tests/tests.vcxproj
+++ b/tests/tests.vcxproj
@@ -179,15 +179,15 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="CalcHashTestFile.txt">
+    <CopyFileToFolders Include="CalcHashTestFile.txt">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </Text>
-    <Text Include="ShasumFailure.txt">
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ShasumFailure.txt">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </Text>
-    <Text Include="ShasumSuccess.txt">
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ShasumSuccess.txt">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-    </Text>
+    </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tests/tests.vcxproj.filters
+++ b/tests/tests.vcxproj.filters
@@ -31,14 +31,14 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <Text Include="ShasumFailure.txt">
+    <CopyFileToFolders Include="CalcHashTestFile.txt">
       <Filter>Resource Files</Filter>
-    </Text>
-    <Text Include="ShasumSuccess.txt">
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ShasumFailure.txt">
       <Filter>Resource Files</Filter>
-    </Text>
-    <Text Include="CalcHashTestFile.txt">
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="ShasumSuccess.txt">
       <Filter>Resource Files</Filter>
-    </Text>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/tests/tests.vcxproj.user
+++ b/tests/tests.vcxproj.user
@@ -1,4 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerEnvironment>OUTPUT_PATH=$(OutputPath)
+$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LocalDebuggerEnvironment>$(LocalDebuggerEnvironment)</LocalDebuggerEnvironment>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi,

this PR adds more tests for calculating and verifying the checksums for relative and absolute paths. I think I covered all possible variations from #1, but only the "lucky paths".

Also I had to do some things first, before running the tests were possible for me:

1. Fix the build as there were absolute path or non-existing path defined in the project config
2. Tests have been fixed. Guess this happened because of your recent changes.
3. Fix the "Debug" environment

I have almost zero knowledge of C++, but I wanted to give back some work to this project. Therefore if you want any changes, convert this PR to draft and we can work on it together.

Thanks.